### PR TITLE
🚀 Hotlink README icon images to jsDelivr CDN rather than GitHub

### DIFF
--- a/_ci.py
+++ b/_ci.py
@@ -7,7 +7,7 @@ readme_path = root / "README.md"
 
 
 def generate_img_tag(file):
-    return f'<img src="png/{file.name}" alt="{file.stem}" width="50">'
+    return f'<img src="https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/{file.name}" alt="{file.stem}" width="50">'
 
 
 imgs = sorted(Path("./png").glob("*.png"))


### PR DESCRIPTION
Consistent with the installation tip, it makes sense to have the icon images displayed in the README be served from jsDelivr CDN more suited to this purpose than GitHub.

This should hopefully alleviate unresponsiveness and issues loading the README sometimes experienced when browsing the repository on GitHub.