### PR TITLE
Add file tree generation GH workflow

### DIFF
--- a/.github/workflows/generate_filetree.yml
+++ b/.github/workflows/generate_filetree.yml
@@ -1,0 +1,31 @@
+name: 🌴 Generate File Tree
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          architecture: "x64"
+
+      - name: Generate File Tree
+        run: python config/tree.py svg png
+
+      - name: Load to GitHub
+        run: |-
+          git diff
+          git config --global user.email "noreply@lammers.media"
+          git config --global user.name "Dashboard Icons Bot"
+          git add file_tree.json
+          git commit -m ":construction_worker: Generates file_tree.json" || exit 0
+          git push

--- a/config/tree.py
+++ b/config/tree.py
@@ -1,0 +1,49 @@
+import os
+import json
+import sys
+
+def folder_to_json(path):
+    tree = {}
+    base_folder_name = os.path.basename(os.path.normpath(path))  # Get the base folder name
+    
+    # Ensure the path doesn't return an empty string or dot.
+    base_folder_name = base_folder_name if base_folder_name else os.path.basename(os.getcwd())
+
+    for root, dirs, files in os.walk(path):
+        # Get the relative path of the root directory
+        relative_path = os.path.relpath(root, path)
+        
+        # Use base folder name for root, and append relative path for subfolders
+        key = base_folder_name if relative_path == '.' else os.path.join(base_folder_name, relative_path)
+
+        # Only add the folder if there are files
+        if files:
+            tree[key] = files
+    
+    return tree
+
+def generate_combined_tree(paths):
+    combined_tree = {}
+
+    for path in paths:
+        # Add folder tree for each path
+        combined_tree.update(folder_to_json(path))
+    
+    return combined_tree
+
+if __name__ == "__main__":
+    # Get the list of folder paths from command-line arguments
+    folder_paths = sys.argv[1:]
+
+    if not folder_paths:
+        print("Please provide at least one folder path.")
+        sys.exit(1)
+
+    # Generate the combined folder tree for all specified paths
+    combined_folder_tree = generate_combined_tree(folder_paths)
+
+    # Write the combined JSON structure to a file named tree.json
+    with open('tree.json', 'w') as f:
+        json.dump(combined_folder_tree, f, indent=4)
+
+    print("Folder tree successfully written to 'tree.json'.")


### PR DESCRIPTION
This repository has more than 1000 files in one folder, so the https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content method doesn't work anymore.

In order to get the content of the repository (to use within an Icon finder for example) it would be better to just get the content of a file that contains the file tree (it also reduces strain on the GH servers) 

The new expected usage would be fetching `https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/tree.json` to get a JSON object containing the path of all the files.

It's pretty easy to interpolate `https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/${FOLDER}/${ICON}` and it reduces the size of the JSON that has to be fetched



